### PR TITLE
docs(examples): add three example use cases for tollbooth

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,6 +42,14 @@ export default defineConfig({
 						{ label: 'CLI', slug: 'reference/cli' },
 					],
 				},
+			{
+					label: 'Examples',
+					items: [
+						{ label: 'AI API Reseller', slug: 'examples/ai-api-reseller' },
+						{ label: 'Video Streaming Paywall', slug: 'examples/video-streaming-paywall' },
+						{ label: 'Multi-Upstream Gateway', slug: 'examples/multi-upstream-gateway' },
+					],
+				},
 			],
 			components: {
 				SiteTitle: './src/components/SiteTitle.astro',

--- a/src/content/docs/examples/ai-api-reseller.md
+++ b/src/content/docs/examples/ai-api-reseller.md
@@ -1,0 +1,111 @@
+---
+title: "Example: AI API Reseller"
+description: Wrap the Anthropic Claude API and resell access per-request via x402 with dynamic pricing by model.
+---
+
+Resell access to the Anthropic Claude API. Clients pay per-request via x402 — pricing adjusts automatically based on which model they request.
+
+## Use case
+
+You hold an Anthropic API key and want to monetize it. Instead of managing API keys, subscriptions, or billing dashboards, you put tollbooth in front of the Anthropic API and charge per-request in USDC. Cheaper models cost less, expensive models cost more.
+
+## Config
+
+```yaml
+# tollbooth.config.yaml
+gateway:
+  port: 3000
+  discovery: true
+
+wallets:
+  base: "0xYourWalletAddress"
+
+accepts:
+  - asset: USDC
+    network: base
+
+upstreams:
+  anthropic:
+    url: "https://api.anthropic.com"
+    headers:
+      x-api-key: "${ANTHROPIC_API_KEY}"
+      anthropic-version: "2023-06-01"
+    timeout: 120
+
+routes:
+  "POST /v1/messages":
+    upstream: anthropic
+    path: "/v1/messages"
+    match:
+      - where: { body.model: "claude-haiku-*" }
+        price: "$0.005"
+      - where: { body.model: "claude-sonnet-*" }
+        price: "$0.015"
+      - where: { body.model: "claude-opus-*" }
+        price: "$0.075"
+    fallback: "$0.015"
+```
+
+### What's going on
+
+- **Single upstream** pointing at `api.anthropic.com` with your API key injected via env var.
+- **One route** (`POST /v1/messages`) mirrors the Anthropic Messages endpoint.
+- **Match rules** inspect `body.model` using glob patterns to set per-model pricing — Haiku is cheap, Opus is premium.
+- **Fallback** catches any model that doesn't match a rule (e.g. new models Anthropic releases).
+
+## Run it
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+npx tollbooth start
+```
+
+## Expected flow
+
+```
+Client                        Tollbooth                     Anthropic
+  │                              │                              │
+  │  POST /v1/messages           │                              │
+  │  { model: "claude-sonnet-…"} │                              │
+  │─────────────────────────────>│                              │
+  │                              │  match body.model →          │
+  │                              │  price: $0.015               │
+  │  402 + payment instructions  │                              │
+  │<─────────────────────────────│                              │
+  │                              │                              │
+  │  (sign $0.015 USDC payment)  │                              │
+  │                              │                              │
+  │  POST /v1/messages           │                              │
+  │  + X-PAYMENT header          │                              │
+  │─────────────────────────────>│                              │
+  │                              │  verify + settle payment     │
+  │                              │                              │
+  │                              │  POST /v1/messages           │
+  │                              │──────────────────────────────>│
+  │                              │                              │
+  │                              │  { content: "..." }          │
+  │                              │<──────────────────────────────│
+  │  200 + Claude response       │                              │
+  │<─────────────────────────────│                              │
+```
+
+## Try it with curl
+
+First request — get the 402:
+
+```bash
+curl -s http://localhost:3000/v1/messages \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-sonnet-4-20250514","max_tokens":256,"messages":[{"role":"user","content":"Hello"}]}'
+```
+
+The response includes a `402 Payment Required` status with payment instructions in the headers. An x402-compatible client (or wallet SDK) reads these instructions, signs the USDC payment, and resends the request with the payment proof attached.
+
+:::tip
+To test locally without real payments, see the [Local Testing](/guides/local-testing/) guide.
+:::
+
+---
+
+**Next:** [Video Streaming Paywall →](/examples/video-streaming-paywall/)

--- a/src/content/docs/examples/multi-upstream-gateway.md
+++ b/src/content/docs/examples/multi-upstream-gateway.md
@@ -1,0 +1,145 @@
+---
+title: "Example: Multi-Upstream Gateway"
+description: Route to different backends based on path and price each upstream independently.
+---
+
+A single tollbooth instance that routes to multiple backend APIs, each with its own pricing. One gateway, many upstreams.
+
+## Use case
+
+You aggregate several third-party APIs behind one paid gateway. Each upstream has different costs and value, so you price them independently. Clients hit a single domain and pay per-request — tollbooth handles routing, auth injection, and payment for all of them.
+
+## Config
+
+```yaml
+# tollbooth.config.yaml
+gateway:
+  port: 3000
+  discovery: true
+
+wallets:
+  base: "0xYourWalletAddress"
+
+accepts:
+  - asset: USDC
+    network: base
+
+upstreams:
+  weather:
+    url: "https://api.weatherapi.com/v1"
+    headers:
+      key: "${WEATHER_API_KEY}"
+
+  geocoding:
+    url: "https://api.mapbox.com"
+    headers:
+      access_token: "${MAPBOX_TOKEN}"
+
+  ai:
+    url: "https://api.openai.com"
+    headers:
+      authorization: "Bearer ${OPENAI_API_KEY}"
+
+routes:
+  # Cheap data endpoint
+  "GET /weather/:city":
+    upstream: weather
+    path: "/current.json?q=${params.city}"
+    price: "$0.005"
+
+  # Mid-tier geocoding
+  "GET /geocode/:query":
+    upstream: geocoding
+    path: "/geocoding/v5/mapbox.places/${params.query}.json"
+    price: "$0.01"
+
+  # Expensive AI — priced by model
+  "POST /v1/chat/completions":
+    upstream: ai
+    type: openai-compatible
+    models:
+      gpt-4o: "$0.05"
+      gpt-4o-mini: "$0.005"
+    fallback: "$0.01"
+```
+
+### What's going on
+
+- **Three upstreams** — weather, geocoding, and AI — each with their own base URL and auth headers.
+- **Path-based routing** sends requests to the right backend based on the public URL path.
+- **Independent pricing** — weather is cheap ($0.005), geocoding is mid-tier ($0.01), AI uses per-model pricing via `type: openai-compatible`.
+- **Path rewriting** — each route maps the public-facing path to the upstream's actual API format.
+- **One wallet** collects payments from all routes.
+
+## Run it
+
+```bash
+export WEATHER_API_KEY="..."
+export MAPBOX_TOKEN="..."
+export OPENAI_API_KEY="sk-..."
+npx tollbooth start
+```
+
+## Expected flow
+
+```
+Client                        Tollbooth                   Upstreams
+  │                              │                              │
+  │  GET /weather/london         │                              │
+  │─────────────────────────────>│                              │
+  │                              │  route → weather upstream    │
+  │                              │  price: $0.005               │
+  │  402 + payment instructions  │                              │
+  │<─────────────────────────────│                              │
+  │                              │                              │
+  │  (sign $0.005 USDC)          │                              │
+  │                              │                              │
+  │  GET /weather/london         │                              │
+  │  + X-PAYMENT header          │                              │
+  │─────────────────────────────>│                              │
+  │                              │  GET /current.json?q=london  │
+  │                              │───────────────────────────> Weather API
+  │                              │                              │
+  │                              │  { temp: 12, ... }           │
+  │                              │<───────────────────────────  │
+  │  200 + weather data          │                              │
+  │<─────────────────────────────│                              │
+  │                              │                              │
+  ├──────────────────────────────┤                              │
+  │                              │                              │
+  │  POST /v1/chat/completions   │                              │
+  │  { model: "gpt-4o" }        │                              │
+  │─────────────────────────────>│                              │
+  │                              │  route → ai upstream         │
+  │                              │  model: gpt-4o → $0.05      │
+  │  402 + payment instructions  │                              │
+  │<─────────────────────────────│                              │
+  │                              │                              │
+  │  ...pay and get response...  │                              │
+```
+
+## Try it with curl
+
+```bash
+# Weather — cheap
+curl -s http://localhost:3000/weather/london
+
+# Geocoding — mid-tier
+curl -s http://localhost:3000/geocode/tokyo
+
+# AI — model-based pricing
+curl -s http://localhost:3000/v1/chat/completions \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hi"}]}'
+```
+
+Each request returns a `402` with a price matching that route's configuration. An x402-compatible client handles payment automatically.
+
+:::tip
+The discovery endpoint at `GET /.well-known/x402` lists all routes and their prices, so clients can display a pricing table before making requests.
+:::
+
+---
+
+**Next:** [Configuration Reference →](/reference/configuration/)

--- a/src/content/docs/examples/video-streaming-paywall.md
+++ b/src/content/docs/examples/video-streaming-paywall.md
@@ -1,0 +1,115 @@
+---
+title: "Example: Video Streaming Paywall"
+description: Pay-per-video using tollbooth with pricing by quality tier (4K, HD, SD).
+---
+
+Charge viewers per-video based on the quality tier they request. Higher quality costs more — no subscriptions, no accounts, just pay and watch.
+
+## Use case
+
+You run a video origin server that serves content at multiple quality tiers (4K, HD, SD). You want to charge viewers per-video in USDC via x402. A 4K stream costs more than SD because it uses more bandwidth and storage.
+
+## Config
+
+```yaml
+# tollbooth.config.yaml
+gateway:
+  port: 3000
+  discovery: true
+
+wallets:
+  base: "0xYourWalletAddress"
+
+accepts:
+  - asset: USDC
+    network: base
+
+upstreams:
+  video-origin:
+    url: "https://cdn.example.com"
+    headers:
+      authorization: "Bearer ${CDN_API_KEY}"
+
+routes:
+  "GET /video/:video_id":
+    upstream: video-origin
+    path: "/streams/${params.video_id}/manifest.m3u8"
+    match:
+      - where: { query.quality: "4k" }
+        price: "$0.25"
+      - where: { query.quality: "hd" }
+        price: "$0.10"
+      - where: { query.quality: "sd" }
+        price: "$0.03"
+    fallback: "$0.10"
+
+  "GET /video/:video_id/thumbnail":
+    upstream: video-origin
+    path: "/streams/${params.video_id}/thumb.jpg"
+    price: "$0.001"
+```
+
+### What's going on
+
+- **Video origin upstream** — your CDN or media server that stores the actual video files.
+- **Main route** (`GET /video/:video_id`) serves the HLS manifest. The `quality` query parameter determines the price.
+- **Match rules** check `query.quality` to price by tier: 4K ($0.25), HD ($0.10), SD ($0.03).
+- **Thumbnail route** is a cheap separate endpoint so clients can preview content before paying for the full video.
+- **Path rewriting** maps the public `/video/:video_id` path to the origin's internal `/streams/:video_id/manifest.m3u8` format.
+
+## Run it
+
+```bash
+export CDN_API_KEY="..."
+npx tollbooth start
+```
+
+## Expected flow
+
+```
+Client                        Tollbooth                   Video Origin
+  │                              │                              │
+  │  GET /video/abc123?quality=hd│                              │
+  │─────────────────────────────>│                              │
+  │                              │  match query.quality →       │
+  │                              │  price: $0.10                │
+  │  402 + payment instructions  │                              │
+  │<─────────────────────────────│                              │
+  │                              │                              │
+  │  (sign $0.10 USDC payment)   │                              │
+  │                              │                              │
+  │  GET /video/abc123?quality=hd│                              │
+  │  + X-PAYMENT header          │                              │
+  │─────────────────────────────>│                              │
+  │                              │  verify + settle payment     │
+  │                              │                              │
+  │                              │  GET /streams/abc123/        │
+  │                              │      manifest.m3u8           │
+  │                              │──────────────────────────────>│
+  │                              │                              │
+  │                              │  (HLS manifest)              │
+  │                              │<──────────────────────────────│
+  │  200 + manifest.m3u8         │                              │
+  │<─────────────────────────────│                              │
+```
+
+## Try it with curl
+
+```bash
+# Get a cheap thumbnail (preview)
+curl -s http://localhost:3000/video/abc123/thumbnail
+
+# Request 4K video — triggers 402
+curl -s http://localhost:3000/video/abc123?quality=4k
+
+# Request SD video — cheaper 402
+curl -s http://localhost:3000/video/abc123?quality=sd
+```
+
+:::note
+This example gates the HLS/DASH manifest behind the paywall. Once the client has the manifest, individual segment fetches go directly to the CDN. For segment-level paywalling, you'd add a separate route for each segment path.
+:::
+
+---
+
+**Next:** [Multi-Upstream Gateway →](/examples/multi-upstream-gateway/)


### PR DESCRIPTION
## Summary

- Add "Examples" section to documentation sidebar navigation
- Add three example guides demonstrating common tollbooth use cases:
  - **AI API Reseller**: Resell Anthropic Claude API access with per-model dynamic pricing
  - **Video Streaming Paywall**: Gate video content by quality tier (4K, HD, SD) with tier-based pricing
  - **Multi-Upstream Gateway**: Route to multiple third-party APIs with independent pricing per upstream
- Each example includes complete configuration, expected flow diagrams, and curl commands for testing