### PR TITLE
chore(config): add link to docs repository

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,7 @@ export default defineConfig({
 			lastUpdated: true,
 			social: [
 				{ icon: 'github', label: 'GitHub', href: 'https://github.com/Loa212/x402-tollbooth' },
+				{ icon: 'github', label: 'Docs repo', href: 'https://github.com/Loa212/tollbooth-docs' },
 			],
 			customCss: ['./src/styles/custom.css'],
 			sidebar: [


### PR DESCRIPTION
## Summary
- Added GitHub social link pointing to the docs repository (`tollbooth-docs`)
- Allows users to easily discover and access the separate documentation repository from the site

Resolves #12

---

Closes #12