### PR TITLE
Add settlement: after-response callout to AI Reseller example

### DIFF
--- a/src/content/docs/examples/ai-api-reseller.md
+++ b/src/content/docs/examples/ai-api-reseller.md
@@ -53,6 +53,10 @@ routes:
 - **Match rules** inspect `body.model` using glob patterns to set per-model pricing — Haiku is cheap, Opus is premium.
 - **Fallback** catches any model that doesn't match a rule (e.g. new models Anthropic releases).
 
+:::caution[Protect clients from upstream failures]
+Since Anthropic is a paid upstream that can return `5xx` errors, consider adding `settlement: after-response` to this route. If the upstream fails, the client's payment is never settled and they keep their funds. See the [Refund Protection](/guides/refund-protection/) guide.
+:::
+
 ## Run it
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a `:::caution` callout to the AI API Reseller example recommending `settlement: after-response` since the upstream (Anthropic) is a paid API that can 5xx
- Links to the Refund Protection guide for details

Closes #15

## Test plan
- [ ] Verify the callout renders correctly on the docs site
- [ ] Confirm the link to `/guides/refund-protection/` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)