### PR TITLE
fix(index): prevent flashing on redirect to welcome page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,15 @@
 ---
-return Astro.redirect("/welcome/");
+// Client-side redirect to /welcome/ — avoids the unstyled "Redirecting..."
+// flash that Astro.redirect() produces in static output mode.
 ---
 
 <html>
 	<head>
-		<style>html, body { background: #17191e; margin: 0; }</style>
+		<meta charset="utf-8">
+		<meta http-equiv="refresh" content="0;url=/welcome/">
+		<link rel="canonical" href="/welcome/">
+		<style>html, body { background: #17191e; margin: 0; height: 100%; }</style>
+		<script is:inline>window.location.replace('/welcome/');</script>
 	</head>
 	<body></body>
 </html>


### PR DESCRIPTION
## Summary

- Replace server-side `Astro.redirect()` with client-side redirect methods to eliminate unstyled "Redirecting..." flash
- Add `<meta http-equiv="refresh">` and JavaScript fallback for redirect
- Add canonical link and charset meta tags
- Improve styling with `height: 100%` to ensure full viewport coverage during initial load
- Document the rationale for client-side approach

## Breaking Changes

None

---

Closes #17