### PR TITLE
fix(docs): clarify GitHub links and move docs repo to footer

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,8 +15,7 @@ export default defineConfig({
 			},
 			lastUpdated: true,
 			social: [
-				{ icon: 'github', label: 'GitHub', href: 'https://github.com/Loa212/x402-tollbooth' },
-				{ icon: 'github', label: 'Docs repo', href: 'https://github.com/Loa212/tollbooth-docs' },
+				{ icon: 'github', label: 'Tollbooth on GitHub', href: 'https://github.com/Loa212/x402-tollbooth' },
 			],
 			customCss: ['./src/styles/custom.css'],
 			sidebar: [
@@ -60,6 +59,7 @@ export default defineConfig({
 			components: {
 				SiteTitle: './src/components/SiteTitle.astro',
 				PageTitle: './src/components/PageTitle.astro',
+				Footer: './src/components/Footer.astro',
 			},
 		}),
 	],

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,77 @@
+---
+import EditLink from 'virtual:starlight/components/EditLink';
+import LastUpdated from 'virtual:starlight/components/LastUpdated';
+import Pagination from 'virtual:starlight/components/Pagination';
+import config from 'virtual:starlight/user-config';
+import { Icon } from '@astrojs/starlight/components';
+---
+
+<footer class="sl-flex">
+	<div class="meta sl-flex">
+		<EditLink />
+		<LastUpdated />
+	</div>
+	<Pagination />
+
+	<div class="docs-repo sl-flex">
+		<a href="https://github.com/Loa212/tollbooth-docs" class="sl-flex">
+			<Icon name="github" />
+			<span>Docs source on GitHub</span>
+		</a>
+	</div>
+
+	{
+		config.credits && (
+			<a class="kudos sl-flex" href="https://starlight.astro.build">
+				<Icon name={'starlight'} /> {Astro.locals.t('builtWithStarlight.label')}
+			</a>
+		)
+	}
+</footer>
+
+<style>
+	footer {
+		flex-direction: column;
+		gap: 1.5rem;
+	}
+	.meta {
+		gap: 0.75rem 3rem;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		margin-top: 3rem;
+		font-size: var(--sl-text-sm);
+		color: var(--sl-color-gray-3);
+	}
+	.meta > :global(p:only-child) {
+		margin-inline-start: auto;
+	}
+
+	.docs-repo {
+		justify-content: center;
+	}
+	.docs-repo a {
+		align-items: center;
+		gap: 0.5em;
+		font-size: var(--sl-text-xs);
+		text-decoration: none;
+		color: var(--sl-color-gray-3);
+	}
+	.docs-repo a:hover {
+		color: var(--sl-color-white);
+	}
+
+	.kudos {
+		align-items: center;
+		gap: 0.5em;
+		margin: 1.5rem auto;
+		font-size: var(--sl-text-xs);
+		text-decoration: none;
+		color: var(--sl-color-gray-3);
+	}
+	.kudos:hover {
+		color: var(--sl-color-white);
+	}
+	.kudos :global(svg) {
+		color: var(--sl-color-orange);
+	}
+</style>


### PR DESCRIPTION
## Summary

- Renamed "GitHub" link label to "Tollbooth on GitHub" for clarity
- Removed confusing "Docs repo" link from top-right social links
- Added custom Footer component with "Docs source on GitHub" link
- Docs repository link is now properly positioned in footer and clearly labeled

## Details

Fixes issue #19 by addressing the confusion around header navigation. The main GitHub link is now explicitly labeled as "Tollbooth on GitHub" so users understand it links to the main project. The docs repository link is removed from the header's social links (where it was unclear) and moved to the footer with a descriptive label, making it more discoverable and contextually appropriate.

---

Closes #19