### PR TITLE
docs: update all references from openai-compatible to token-based

### DIFF
--- a/src/content/docs/examples/ai-api-reseller.md
+++ b/src/content/docs/examples/ai-api-reseller.md
@@ -70,7 +70,7 @@ routes:
 
 ## Option B: Token-based pricing
 
-Charge based on actual token usage. Set `type: openai-compatible` and tollbooth reads the `model` field from the request body automatically — no match rules needed.
+Charge based on actual token usage. Set `type: token-based` and tollbooth reads the `model` field from the request body automatically — no match rules needed.
 
 ```yaml
 # tollbooth.config.yaml
@@ -97,7 +97,7 @@ routes:
   "POST /v1/messages":
     upstream: anthropic
     path: "/v1/messages"
-    type: openai-compatible
+    type: token-based
     models:
       claude-haiku-4-5-20251001: "$0.001/1k-tokens"
       claude-sonnet-4-5-20250929: "$0.005/1k-tokens"
@@ -107,7 +107,7 @@ routes:
 
 ### What's going on
 
-- **`type: openai-compatible`** tells tollbooth to extract the `model` from the request body and price by token count.
+- **`type: token-based`** tells tollbooth to extract the `model` from the request body and price by token count. (`openai-compatible` is also accepted as an alias.)
 - **`models` map** sets per-model token rates — you control the markup per 1k tokens.
 - **Fallback** applies a default token rate for any model not explicitly listed.
 - No match rules required — the gateway handles model detection automatically.

--- a/src/content/docs/examples/multi-upstream-gateway.md
+++ b/src/content/docs/examples/multi-upstream-gateway.md
@@ -66,7 +66,7 @@ routes:
   # Expensive AI — priced by model
   "POST /v1/chat/completions":
     upstream: ai
-    type: openai-compatible
+    type: token-based
     models:
       gpt-4o: "$0.05"
       gpt-4o-mini: "$0.005"
@@ -77,7 +77,7 @@ routes:
 
 - **Three upstreams** — weather, geocoding, and AI — each with their own base URL and auth headers.
 - **Path-based routing** sends requests to the right backend based on the public URL path.
-- **Independent pricing** — weather is cheap ($0.005), geocoding is mid-tier ($0.01), AI uses per-model pricing via `type: openai-compatible`.
+- **Independent pricing** — weather is cheap ($0.005), geocoding is mid-tier ($0.01), AI uses per-model pricing via `type: token-based`.
 - **Path rewriting** — each route maps the public-facing path to the upstream's actual API format.
 - **One wallet** collects payments from all routes.
 

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -16,6 +16,7 @@ keywords:
   - environment variables
   - path parameters
   - path rewriting
+  - token-based
   - OpenAI-compatible
   - pricing format
 ---
@@ -74,7 +75,7 @@ routes:
 
   "POST /v1/chat/completions":
     upstream: openai
-    type: openai-compatible
+    type: token-based
     models:
       gpt-4o: "$0.05"
       gpt-4o-mini: "$0.005"
@@ -279,9 +280,9 @@ routes:
     price: "$0.015"
 ```
 
-### OpenAI-Compatible Routes
+### Token-Based Routes
 
-For proxying OpenAI-compatible APIs (OpenAI, OpenRouter, LiteLLM, Ollama, etc.), set `type: openai-compatible` to enable automatic model-based pricing without writing match rules.
+For proxying OpenAI-compatible APIs (OpenAI, OpenRouter, LiteLLM, Ollama, etc.), set `type: token-based` to enable automatic model-based pricing without writing match rules. `openai-compatible` is also accepted as an alias.
 
 The gateway auto-extracts the `model` field from the JSON request body and prices the request using a built-in table of common models (GPT-4o, Claude, Gemini, Llama, Mistral, DeepSeek, etc.).
 
@@ -297,11 +298,11 @@ upstreams:
 routes:
   "POST /v1/chat/completions":
     upstream: openai
-    type: openai-compatible
+    type: token-based
 
   "POST /v1/completions":
     upstream: openai
-    type: openai-compatible
+    type: token-based
 ```
 
 #### Override or extend model pricing
@@ -312,7 +313,7 @@ Add a `models` map to set custom prices or add models not in the default table:
 routes:
   "POST /v1/chat/completions":
     upstream: openai
-    type: openai-compatible
+    type: token-based
     models:
       gpt-4o: "$0.05"          # override default
       gpt-4o-mini: "$0.005"    # override default
@@ -322,7 +323,7 @@ routes:
 
 #### Price resolution order
 
-When pricing an OpenAI-compatible request, the gateway checks:
+When pricing a token-based request, the gateway checks:
 
 1. `models` (your route overrides) — exact match
 2. Built-in default table — exact match


### PR DESCRIPTION
## Summary
- Replaced all `type: openai-compatible` with `type: token-based` across Configuration Reference, AI API Reseller example, and Multi-Upstream Gateway example
- Added `openai-compatible` alias mention in the Configuration Reference and AI API Reseller docs
- Added `token-based` keyword to Configuration Reference frontmatter

## Test plan
- [ ] Verify all YAML examples show `type: token-based`
- [ ] Verify `openai-compatible` is only mentioned as an alias (2 occurrences)
- [ ] Build the docs site and confirm no broken links or rendering issues

Closes #29