### PR TITLE
docs: document free routes (price "$0")

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -69,6 +69,7 @@ export default defineConfig({
 			{
 					label: 'Examples',
 					items: [
+						{ label: 'Paid Articles Blog', slug: 'examples/paid-articles-blog' },
 						{ label: 'AI API Reseller', slug: 'examples/ai-api-reseller' },
 						{ label: 'Video Streaming Paywall', slug: 'examples/video-streaming-paywall' },
 						{ label: 'Multi-Upstream Gateway', slug: 'examples/multi-upstream-gateway' },

--- a/src/content/docs/examples/paid-articles-blog.md
+++ b/src/content/docs/examples/paid-articles-blog.md
@@ -1,0 +1,118 @@
+---
+title: "Example: Paid Articles Blog"
+description: Mix free and paid routes — serve public listings for free and charge per-article using price "$0" to bypass payment.
+keywords:
+  - blog
+  - articles
+  - free routes
+  - mixed pricing
+  - paywall
+  - content monetization
+  - price zero
+  - transparent proxy
+---
+
+Monetize a blog API by keeping listings free and charging readers per-article. Free routes use `price: "$0"` to skip the x402 payment flow entirely — no 402 response, no wallet interaction.
+
+## Use case
+
+You run a blog backend and want to:
+
+- Let anyone browse the homepage and article list for free
+- Charge a small fee to read the full content of an article
+
+## Config
+
+```yaml
+# tollbooth.config.yaml
+gateway:
+  port: 3000
+  discovery: true
+
+wallets:
+  base: "0xYourWalletAddress"
+
+accepts:
+  - asset: USDC
+    network: base
+
+upstreams:
+  blog:
+    url: "https://api.myblog.com"
+
+routes:
+  "GET /posts":
+    upstream: blog
+    price: "$0"              # free — list all posts
+
+  "GET /posts/:slug":
+    upstream: blog
+    path: "/posts/${params.slug}"
+    price: "$0.005"          # paid — read full article
+```
+
+## What's going on
+
+- **`GET /posts`** is free. `price: "$0"` tells tollbooth to skip the x402 flow and proxy the request directly — no payment required, no 402 response.
+- **`GET /posts/:slug`** is paid. Clients receive a `402 Payment Required` response with payment instructions, sign a $0.005 USDC payment, and resend the request to get the full article.
+
+## Expected flow
+
+```
+Client                        Tollbooth                     Blog API
+  │                              │                              │
+  │  GET /posts                  │                              │
+  │─────────────────────────────>│  price: $0 → skip payment    │
+  │                              │  GET /posts                  │
+  │                              │─────────────────────────────>│
+  │                              │  [{ slug, title, … }, …]     │
+  │  200 + post list             │<─────────────────────────────│
+  │<─────────────────────────────│                              │
+  │                              │                              │
+  │  GET /posts/my-article       │                              │
+  │─────────────────────────────>│  price: $0.005 → require pay │
+  │  402 + payment instructions  │                              │
+  │<─────────────────────────────│                              │
+  │                              │                              │
+  │  (sign $0.005 USDC payment)  │                              │
+  │                              │                              │
+  │  GET /posts/my-article       │                              │
+  │  + X-PAYMENT header          │                              │
+  │─────────────────────────────>│                              │
+  │                              │  verify + settle payment     │
+  │                              │  GET /posts/my-article       │
+  │                              │─────────────────────────────>│
+  │                              │  { slug, title, body, … }    │
+  │  200 + full article          │<─────────────────────────────│
+  │<─────────────────────────────│                              │
+```
+
+Notice that `GET /posts` goes straight through — no 402 step, no payment headers. The route behaves like a plain reverse proxy.
+
+## Run it
+
+```bash
+npx tollbooth start
+```
+
+## Try it with curl
+
+Free route — returns immediately:
+
+```bash
+curl http://localhost:3000/posts
+```
+
+Paid route — returns 402 with payment instructions:
+
+```bash
+curl http://localhost:3000/posts/my-article
+```
+
+:::tip
+To test locally without real payments, see the [Local Testing](/guides/local-testing/) guide.
+:::
+
+---
+
+**Next:** [AI API Reseller →](/examples/ai-api-reseller/)

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -50,6 +50,10 @@ upstreams:
       authorization: "Bearer ${API_KEY}"
 
 routes:
+  "GET /health":
+    upstream: myapi
+    price: "$0"
+
   "GET /data":
     upstream: myapi
     price: "$0.01"
@@ -59,8 +63,8 @@ This tells tollbooth:
 
 - Listen on port 3000
 - Accept USDC payments on Base
-- Proxy `GET /data` to `https://api.example.com/data`
-- Charge $0.01 per request
+- Proxy `GET /health` for free — `price: "$0"` skips the x402 payment flow entirely
+- Proxy `GET /data` and charge $0.01 per request via x402
 - Expose discovery metadata at `/.well-known/x402`
 
 ## Start the gateway

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -254,6 +254,27 @@ routes:
 | `metadata` | `Record<string, unknown>` | — | Arbitrary metadata included in discovery responses |
 | `facilitator` | `string` | from top-level `facilitator` | Override the facilitator URL for this route |
 
+### Free routes (no payment)
+
+Set `price: "$0"` to bypass the x402 payment flow entirely. The route acts as a transparent proxy — no `402` response, no payment required.
+
+```yaml
+routes:
+  "GET /health":
+    upstream: myapi
+    price: "$0"           # free — proxied directly, no payment
+
+  "GET /data":
+    upstream: myapi
+    price: "$0.01"        # paid — requires x402 payment
+```
+
+This is useful for health checks, public listings, or mixed free/paid APIs where some endpoints should be openly accessible.
+
+:::note
+If `defaults.price` is set to `"$0"`, all routes without an explicit `price` are free by default.
+:::
+
 ### Path parameters
 
 Route paths support Express-style parameters with `:param` syntax:
@@ -439,6 +460,7 @@ Prices are specified as dollar strings and converted to USDC micro-units (6 deci
 
 | Dollar string | USDC micro-units | Actual USDC |
 |---------------|-----------------|-------------|
+| `"$0"` | 0 | Free — skips x402 payment flow |
 | `"$0.001"` | 1,000 | 0.001 USDC |
 | `"$0.01"` | 10,000 | 0.01 USDC |
 | `"$0.05"` | 50,000 | 0.05 USDC |


### PR DESCRIPTION
## Summary
- **Configuration Reference**: added "Free routes" subsection explaining `price: "$0"` bypasses x402 entirely, added `$0` row to pricing format table, added note about `defaults.price: "$0"`
- **Getting Started**: updated quickstart config to show mixed free (`GET /health`) + paid (`GET /data`) routes
- **New Example — Paid Articles Blog**: end-to-end example with free listing endpoint and paid article endpoint, including flow diagram and curl examples
- **Sidebar**: added "Paid Articles Blog" entry under Examples

Closes #38

## Test plan
- [ ] `pnpm build` passes
- [ ] `/reference/configuration/` — "Free routes" subsection renders after route fields table; `$0` row appears in pricing table
- [ ] `/getting-started/` — config shows both free and paid routes with updated explanation
- [ ] `/examples/paid-articles-blog/` — new page renders with config, flow diagram, and curl examples
- [ ] Sidebar shows "Paid Articles Blog" under Examples